### PR TITLE
Update cuda.c

### DIFF
--- a/src/cuda.c
+++ b/src/cuda.c
@@ -33,7 +33,6 @@ void check_error(cudaError_t status)
         const char *s = cudaGetErrorString(status);
         char buffer[256];
         printf("CUDA Error: %s\n", s);
-        assert(0);
         snprintf(buffer, 256, "CUDA Error: %s", s);
         error(buffer);
     } 
@@ -42,7 +41,6 @@ void check_error(cudaError_t status)
         const char *s = cudaGetErrorString(status);
         char buffer[256];
         printf("CUDA Error Prev: %s\n", s);
-        assert(0);
         snprintf(buffer, 256, "CUDA Error Prev: %s", s);
         error(buffer);
     } 


### PR DESCRIPTION
Calling assert(0) in check_error causes an abort before the error message is written.
The error() method calls assert (and exit(-1)) anyway, so no need to assert here.